### PR TITLE
Raise on ManifestFileNotFound

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 import Config
 
 config :phoenix, :json_library, Jason
+
+config :vite_phx, :release_app, :vite_phx

--- a/lib/vite/manifest_reader.ex
+++ b/lib/vite/manifest_reader.ex
@@ -3,7 +3,19 @@ defmodule Vite.ManifestReader do
   Finds `manifest.json` in releases, keeps the content in-memory
   """
   alias Vite.{Cache, Config}
-  require Logger
+
+  defmodule ManifestNotFoundError do
+    defexception [:manifest_file]
+
+    @impl true
+    def message(e) do
+      """
+      Could not find static manifest at #{inspect(e.manifest_file)}.
+        Run "mix phx.digest" after building your static files
+        or remove the configuration from "config/prod.exs".
+      """
+    end
+  end
 
   def read_vite() do
     case Cache.get(:vite_manifest) do
@@ -23,11 +35,7 @@ defmodule Vite.ManifestReader do
     if File.exists?(full_vite_manifest) do
       full_vite_manifest |> File.read!() |> Config.json_library().decode!()
     else
-      Logger.error(
-        "Could not find static manifest at #{inspect(full_vite_manifest)}. " <>
-          "Run \"mix phx.digest\" after building your static files " <>
-          "or remove the configuration from \"config/prod.exs\"."
-      )
+      raise ManifestNotFoundError, manifest_file: full_vite_manifest
     end
   end
 

--- a/test/manitest_reader_test.exs
+++ b/test/manitest_reader_test.exs
@@ -1,0 +1,14 @@
+defmodule Vite.ManifestReaderTest do
+  use ExUnit.Case
+
+  alias Vite.ManifestReader
+  alias Vite.ManifestReader.ManifestNotFoundError
+
+  describe "read_vite/0" do
+    test "to raise on missing file in `:prod` mode" do
+      assert_raise ManifestNotFoundError, fn ->
+        ManifestReader.read_vite(:prod)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #7 - Missing file now raises error.

Raising the error looks like this:

```
iex(1)> raise Vite.ManifestReader.ManifestNotFoundError, manifest_file: "manifest.json"
** (Vite.ManifestReader.ManifestNotFoundError) Could not find static manifest at "manifest.json".
  Run "mix phx.digest" after building your static files
  or remove the configuration from "config/prod.exs".
```