### PR TITLE
Fixes #9: Handle circular references

### DIFF
--- a/lib/vite/manifest.ex
+++ b/lib/vite/manifest.ex
@@ -48,10 +48,20 @@ defmodule Vite.Manifest do
   defp convert_item(acc, raw_data, :import) do
     css = Map.get(raw_data, "css", [])
     imports = Map.get(raw_data, "imports", [])
+    import_module = {:import_module, Map.get(raw_data, "file")}
+
     acc = acc ++ Enum.map(css, fn file -> {:import_css, file} end)
-    acc = acc ++ [{:import_module, Map.get(raw_data, "file")}]
-    acc = Enum.reduce(imports, acc, fn file, innerAcc -> handle_import(innerAcc, file) end)
-    acc |> Enum.uniq()
+
+    case Enum.member?(acc, import_module) do
+      true ->
+        acc
+
+      false ->
+        acc = acc ++ [import_module]
+
+        acc = Enum.reduce(imports, acc, fn file, innerAcc -> handle_import(innerAcc, file) end)
+        acc |> Enum.uniq()
+    end
   end
 
   @spec get_file(binary()) :: entry_value()

--- a/test/fixtures/circular-imports.json
+++ b/test/fixtures/circular-imports.json
@@ -1,0 +1,38 @@
+{
+  "_module_c-CEsvvVSb.js": {
+    "file": "assets/module_c-CEsvvVSb.js",
+    "name": "module_c",
+    "imports": [
+      "_module_a-UvMMXHBe.js",
+      "_module_b-BL0iFxLQ.js"
+    ]
+  },
+  "_module_a-UvMMXHBe.js": {
+    "file": "assets/module_a-UvMMXHBe.js",
+    "name": "module_a",
+    "imports": [
+      "_module_c-CEsvvVSb.js"
+    ]
+  },
+  "_module_b-BL0iFxLQ.js": {
+    "file": "assets/module_b-BL0iFxLQ.js",
+    "name": "module_b",
+    "imports": [
+      "_module_a-UvMMXHBe.js"
+    ]
+  },
+  "src/main.tsx": {
+    "file": "assets/main-Di0ERxQQ.js",
+    "name": "main",
+    "src": "src/main.tsx",
+    "isEntry": true,
+    "imports": [
+      "_module_a-UvMMXHBe.js",
+      "_module_b-BL0iFxLQ.js",
+      "_module_c-CEsvvVSb.js"
+    ],
+    "css": [
+      "assets/main-DuLJnGy9.css"
+    ]
+  }
+}

--- a/test/manifest_test.exs
+++ b/test/manifest_test.exs
@@ -36,5 +36,31 @@ defmodule Vite.ManifestTest do
                  {:import_module, "assets/vendor.2c7f0e08.js"}
                ]
     end
+
+    test "circular" do
+      Config.vite_manifest("test/fixtures/circular-imports.json")
+
+      assert Manifest.entries() ==
+               [
+                 [
+                   {:entry_name, "src/main.tsx"},
+                   {:css, "assets/main-DuLJnGy9.css"},
+                   {:module, "assets/main-Di0ERxQQ.js"},
+                   {:import_module, "assets/module_a-UvMMXHBe.js"},
+                   {:import_module, "assets/module_c-CEsvvVSb.js"},
+                   {:import_module, "assets/module_b-BL0iFxLQ.js"}
+                  ]
+               ]
+
+      assert Manifest.entry("src/main.tsx") ==
+        [
+          {:entry_name, "src/main.tsx"},
+          {:css, "assets/main-DuLJnGy9.css"},
+          {:module, "assets/main-Di0ERxQQ.js"},
+          {:import_module, "assets/module_a-UvMMXHBe.js"},
+          {:import_module, "assets/module_c-CEsvvVSb.js"},
+          {:import_module, "assets/module_b-BL0iFxLQ.js"}
+        ]
+    end
   end
 end


### PR DESCRIPTION
Fixes #9

Before adding the file to the list, check if the item hasn't been added before.
If the list of references is very large, then this might not be the most efficient method.
But if that happens, then I think there are bigger problems in their codebase.